### PR TITLE
Fixed default number of days off.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -54,7 +54,7 @@ function setVarDefaults() {
     rollover = 0;
     remaining = 0;
     dayDiff = 0;
-    totalDaysOff = 3;
+    totalDaysOff = 5;
     pastDaysOff = 0;
     startDate = "08/22/2016";
     endDate = "12/17/2016";


### PR DESCRIPTION
5 probably makes more sense for the fall semester since most people will be gone for the weekend over Thanksgiving break.